### PR TITLE
fix element disabled color

### DIFF
--- a/themes/cyan-light.json
+++ b/themes/cyan-light.json
@@ -34,7 +34,7 @@
 				"element.hover": "#B1C6CC",
 				"element.active": "#3eb2c120",
 				"element.selected": "#b8dde090",
-				"element.disabled": "#3C3C3C",
+				"element.disabled": "#D0D8DC",
 				"drop_target.background": null,
 				"ghost_element.background": null,
 				"ghost_element.hover": "#B1C9CC40",


### PR DESCRIPTION
Some UI elements derive their color from `element.disabled`, and in this light color scheme, having the disabled be a very dark color clashes in the settings toggle element.

I looked up its usage in the zed's codebase, and it is used in toggle.rs, button_like.rs icon.rs, avatar.rs and commit_tooltip.rs. All these that are mentioned are button like in behavior and on a light theme, a light gray is much more suitable than a close to black color

## Before
<div>
<img width="147" height="235" alt="image" src="https://github.com/user-attachments/assets/7d5b0006-020a-408b-9d6a-afcf4f4b6e3d" />
</div>

## After
<div>
<img width="131" height="220" alt="image" src="https://github.com/user-attachments/assets/db12cb4a-7cfd-42c4-8075-cf7bcd7daf6d" />
</div>

